### PR TITLE
Feature/remove type

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -39,7 +39,7 @@ Check out [proposals](./docs/Proposals.md).
 - [ ] `Final` state types?
 - [ ] `History` state types?
 - [ ] `onEntry` & `onExit`
-- [ ] Simplify `type` to `parallel` since all other types are derived automatically
-- [ ] Unit tests!
-- [ ] Should `util.js` accept React components outright? Or should they be transformed into arrays ahead of time? via (`React.Children.toArray`);
+- [x] Simplify `type` to `parallel` since all other types are derived automatically
+- [x] Unit tests!
+- [x] Arguments passed into `util.js` should already be formatted with `React.Children.toArray`
 - [ ] Implement `microStep` (the executin of a single transition) and `macroStep` (execution of multiple microSteps after which Machien is in a stable state i.e. depleted internal event queue).

--- a/src/Machine.jsx
+++ b/src/Machine.jsx
@@ -52,7 +52,7 @@ function Machine ({ children: machineChildren, history: machineHistory, id: mach
         params
     });
 
-    function resolvePath(path) {
+    const resolvePath = (path) => {
         const url = injectUrlParams(path, state.params);
 
         if (url !== history.location.pathname) {
@@ -60,7 +60,7 @@ function Machine ({ children: machineChildren, history: machineHistory, id: mach
         }
     }
 
-    function send(event, data = null) {
+    const send = (event, data = null) => {
         const targetState = selectTransition(event, state.current, normalized);
 
         if (targetState) {

--- a/src/State.jsx
+++ b/src/State.jsx
@@ -1,6 +1,6 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, { useContext } from 'react';
 import { MachineContext } from './Machine';
-import { getChildrenOfType, getChildStateNodes, isCurrentStack, isExactStack } from './util';
+import { isCurrentStack, isExactStack } from './util';
 
 export const StateNodeContext = React.createContext({
     id: null,
@@ -10,7 +10,7 @@ export const StateNodeContext = React.createContext({
 StateNodeContext.displayName = 'StateNode';
 
 function State(props) {
-    const { children, component: Component, id, initial, onEntry, onExit, path } = props;
+    const { children, component: Component, id, initial, path } = props;
     const machineContext = useContext(MachineContext);
     const { event: machineEvent, current, history, id: machineId, params, resolvePath, send: machineSend } = machineContext;
     const { id: parentId, path: parentPath, stack: parentStack } = useContext(StateNodeContext);

--- a/src/util.js
+++ b/src/util.js
@@ -143,7 +143,7 @@ const normalizeChildStateProps = (stateNodes, rootId) => {
         initialIndex = initialIndex >= 0 ? initialIndex : 0;
 
         return stateNodes.reduce((acc, stateNode, i) => {
-            const { children, id, path = '/', type } = stateNode.props;
+            const { children, id, parallel, path = '/' } = stateNode.props;
             const childStates = getChildStateNodes(React.Children.toArray(children));
             const transitions = getChildrenOfType(React.Children.toArray(children), 'Transition')
                 .map(({ props }) => ({
@@ -161,7 +161,7 @@ const normalizeChildStateProps = (stateNodes, rootId) => {
                 path,
                 stack: '.' + id,
                 transitions,
-                type: type === 'parallel' ? 'parallel'
+                type: parallel ? 'parallel'
                     : childStates.length === 0 ? 'atomic'
                     : childStates.length > 1 ? 'compound' : 'default'
             });


### PR DESCRIPTION
Remove `type` attribute from `<State/>`, and replace with `parallel` boolean.  This simplifies the interface, because there are many possible state `type`s, but `parallel` is boolean. The true `type` is only used internally, and can be inferred from composition (i.e. a `<State/>` with no children is `atomic`, while one with multiple children is `compound`.