### PR TITLE
Dynamic Route Parameter Patch

### DIFF
--- a/src/Machine.jsx
+++ b/src/Machine.jsx
@@ -67,6 +67,17 @@ function Machine ({ children: machineChildren, history: machineHistory, id: mach
                 const { path, stack } = getAtomic(targetNode.stack, normalizedChildStates);
                 const url = injectUrlParams(path, params);
 
+                if (!url) {
+                    log({
+                        type: 'INVALID_TRANSITION_URL',
+                        payload: {
+                            event,
+                            target: { params, path, state: stack }
+                        }
+                    });
+                    return;
+                }
+
                 if (url !== history.location.pathname) {
                     history.push(url, { target: stack });
                 } else {

--- a/src/Machine.jsx
+++ b/src/Machine.jsx
@@ -122,7 +122,7 @@ function Machine ({ children: machineChildren, history: machineHistory, id: mach
         }
 
         if (ignoreHash && state.location.hash !== location.hash) {
-            setState((prevState) => ({ ...state, location: history.location, params }));
+            setState((prevState) => ({ ...prevState, location: history.location, params }));
             return;
         }
 

--- a/src/__test__/Machine.test.jsx
+++ b/src/__test__/Machine.test.jsx
@@ -167,6 +167,26 @@ describe('<Machine/>', () => {
         expect(screen.queryByText('Child 2')).toBeTruthy();
     });
 
+    test('Does not push invalid dynamic URLs when required params are missing', () => {
+        const [ history ] = renderWithNavigation(<State id='parent'>
+            <State id='child-1' path='/child-1' component={({ machine }) => <div>
+                <h1>Child 1</h1>
+                <button onClick={event => machine.send('test-event-1', { params: {} })}>Fire event</button>
+            </div>}>
+                <Transition event='test-event-1' target='child-2'/>
+            </State>
+            <State id='child-2' path='/session/:sessionId' component={generic('Child 2')}/>
+        </State>);
+
+        expect(history.location.pathname).toBe('/child-1');
+        expect(screen.queryByText('Child 1')).toBeTruthy();
+
+        userEvent.click(screen.queryByText(/Fire event/i));
+        expect(history.location.pathname).toBe('/child-1');
+        expect(screen.queryByText('Child 1')).toBeTruthy();
+        expect(screen.queryByText('Child 2')).toBeFalsy();
+    });
+
     test('Transitions state & resolves URL upon event emission, even if the <Transition/> is an ancestor', () => {
         const [ history ] = renderWithNavigation(<State id='parent'>
             <Transition event='test-event-1' target='child-2'/>
@@ -356,6 +376,34 @@ describe('<Machine/>', () => {
         expect(history.location.pathname).toBe('/parent');
         expect(history.location.hash).toBeNull();
         expect(screen.queryByText('Child 2')).toBeTruthy();
+    });
+
+    test('Preserves the current state when ignoreHash handles a hash-only history update', () => {
+        const [ history ] = renderWithNavigation(<State id='parent' path='/parent'>
+            <State id='child-1' path='/child-1' component={({ machine }) => <div>
+                <h1>Child 1</h1>
+                <button onClick={event => machine.send('test-event-1')}>Fire event</button>
+            </div>}>
+                <Transition event='test-event-1' target='child-2'/>
+            </State>
+            <State id='child-2' path='/child-2' component={generic('Child 2')}/>
+        </State>,
+        [ '/child-1#hash=true' ],
+        { ignoreHash: true });
+
+        expect(history.location.pathname).toBe('/child-1');
+        expect(history.location.hash).toBe('#hash=true');
+        expect(screen.queryByText('Child 1')).toBeTruthy();
+
+        userEvent.click(screen.queryByText(/Fire event/i));
+        expect(history.location.pathname).toBe('/child-2');
+        expect(screen.queryByText('Child 2')).toBeTruthy();
+
+        act(() => history.push({ hash: '#hash=false' }));
+        expect(history.location.pathname).toBe('/child-2');
+        expect(history.location.hash).toBe('#hash=false');
+        expect(screen.queryByText('Child 2')).toBeTruthy();
+        expect(screen.queryByText('Child 1')).toBeFalsy();
     });
 
     test('Passes on guarded <Transition/>s', () => {

--- a/src/__test__/util.test.jsx
+++ b/src/__test__/util.test.jsx
@@ -112,6 +112,9 @@ describe('utility functions', () => {
         expect(injectUrlParams('/:dynamicPath/static-path', params)).toBe('/dynamic-path/static-path');
         expect(injectUrlParams('/static-path/:dynamicPath', params)).toBe('/static-path/dynamic-path');
         expect(injectUrlParams('/static-path/:dynamicPath/another-static-path', params)).toBe('/static-path/dynamic-path/another-static-path');
+        expect(injectUrlParams('/:missingParam', params)).toBeNull();
+        expect(injectUrlParams('/:dynamicPath', { dynamicPath: undefined })).toBeNull();
+        expect(injectUrlParams('/:dynamicPath', { dynamicPath: null })).toBeNull();
     });
 
     test.skip('isAtomic', () => {

--- a/src/util.js
+++ b/src/util.js
@@ -45,23 +45,27 @@ const isRootStack = stack => !stack.match(/\./g);
 const isNotFound = stack => stack.split('.').pop() === '*';
 const segmentize = url => url.split('/').filter(Boolean);
 
-const injectUrlParams = (path, params) => {
+const injectUrlParams = (path, params = {}) => {
     const url = segmentize(path).map(seg => {
         if (isDynamicSegment(seg)) {
             const param = seg.replace(':', '');
 
-            if (Object.keys(params).includes(param)) {
+            if (params[param] !== undefined && params[param] !== null) {
                 return params[param].toString();
             } else {
                 console.error(`Cannot push to a dynamic URL without supplying the proper parameters: ${seg} parameter is missing.`);
-                return 'undefined';
+                return null;
             }
         }
 
         return seg;
-    }).join('/');
+    });
 
-    return '/' + url + (window.location.search ? window.location.search : '');
+    if (url.includes(null)) {
+        return null;
+    }
+
+    return '/' + url.join('/') + (window.location.search ? window.location.search : '');
 }
 
 const deriveStateFromUrl = (url, normalizedChildStates, rootId) => {
@@ -277,7 +281,7 @@ const selectTransition = (event, currentStack, normalizedChildStates) => {
     return selectTransition(event, parentStack, normalizedChildStates);
 }
 
-const urlMatchesPathname = (pathname, url) => pathname !== url.split('?')[0];
+const urlMatchesPathname = (pathname, url) => url ? pathname !== url.split('?')[0] : false;
 
 export {
     classNames,


### PR DESCRIPTION
Guard against navigating to dynamic routes when required params are missing. 

- `Machine.jsx` now skips pushing if `injectUrlParams` returns `null` and logs an `INVALID_TRANSITION_URL` entry. 
- `util.js: injectUrlParams` defaults `params={}`, returns `null` for missing/null/undefined params (avoids inserting 'undefined'), fixes path joining, and `urlMatchesPathname` is guarded for null URLs. 
- Added tests in `Machine.test.jsx` and `util.test.jsx` to cover missing-param behavior and hash-only history updates. 
- These changes prevent broken pushes and make URL param handling more robust.